### PR TITLE
Allow usage on Rack 1.5.X

### DIFF
--- a/rackheader.gemspec
+++ b/rackheader.gemspec
@@ -16,5 +16,5 @@ Gem::Specification.new do |gem|
   gem.version       = Rack::Header::VERSION
   
   gem.add_development_dependency 'rake'
-  gem.add_dependency 'rack', '~> 1.4.1'
+  gem.add_dependency 'rack', '>= 1.4.1'
 end


### PR DESCRIPTION
Rack is now at 1.5.X

I did this a while ago and found myself always pointing my Gemfiles to my fork instead of https://rubygems.org. Would be cool to merge and release this.
