### PR TITLE
Set response headers using environment variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,12 @@ run Rack::Lobster.new
 
     $ rackup config.ru
 
+### HTTP_* environment variables
+
+In addition to specifying static headers in your application config, you can also set headers using environment variables.
+
+For example, if you want to set the `X-Robots-Tag` only in certain environments, you can add the `HTTP_X_ROBOTS_TAG` environment variable.
+
 ## Contributing
 
 1. Fork it

--- a/lib/rack/header/context.rb
+++ b/lib/rack/header/context.rb
@@ -1,16 +1,25 @@
 module Rack::Header
   class Context
     def initialize(app, headers = {})
-      @app, @headers = app, headers
+      @app = app
+
+      # Map HTTP_* environment variables to response headers
+      @headers = Hash[*ENV.select {|k,v| k.start_with? 'HTTP_'}
+                          .collect {|k,v| [k.sub(/^HTTP_/, ''), v]}
+                          .collect {|k,v| [k.split('_').collect(&:capitalize).join('-'), v]}
+                          .flatten]
+
+      @headers = headers.merge(@headers)
     end
     
     def call(env)
       status, headers, response = @app.call(env)
+
       @headers.each do |k,v|
         headers[k] = v
       end
       headers.delete_if { |k,v| v.nil? }
-      
+
       [status, headers, response]
     end
   end


### PR DESCRIPTION
In addition to specifying static headers in your application config, you can also set headers using environment variables.

For example, if you want to set the `X-Robots-Tag` only in certain environments, you can add the `HTTP_X_ROBOTS_TAG` environment variable.